### PR TITLE
Adding speaker condition to prosodic features

### DIFF
--- a/TTS/tts/utils/synthesis.py
+++ b/TTS/tts/utils/synthesis.py
@@ -69,6 +69,7 @@ def run_model_torch(
     model: nn.Module,
     inputs: torch.Tensor,
     speaker_id: int = None,
+    cond_speaker_id: ind = None,
     style_mel: torch.Tensor = None,
     d_vector: torch.Tensor = None,
     language_id: torch.Tensor = None,
@@ -99,6 +100,7 @@ def run_model_torch(
         aux_input={
             "x_lengths": input_lengths,
             "speaker_ids": speaker_id,
+            "cond_speaker_ids": cond_speaker_id,
             "d_vectors": d_vector,
             "style_mel": style_mel,
             "language_ids": language_id,
@@ -214,6 +216,7 @@ def synthesis(
     use_cuda,
     ap,
     speaker_id=None,
+    cond_speaker_id=None,
     style_wav=None,
     style_representation=None,
     enable_eos_bos_chars=False,  # pylint: disable=unused-argument
@@ -310,7 +313,7 @@ def synthesis(
         text_inputs = tf.expand_dims(text_inputs, 0)
     # synthesize voice
     if backend == "torch":
-        outputs = run_model_torch(model, text_inputs, speaker_id, style_mel, d_vector=d_vector, language_id=language_id, style_id = style_id, diff_t = diff_t, z = z, pitch_control = pitch_control)
+        outputs = run_model_torch(model, text_inputs, speaker_id, style_mel, d_vector=d_vector, language_id=language_id, style_id = style_id, cond_speaker_id = cond_speaker_id, diff_t = diff_t, z = z, pitch_control = pitch_control)
         model_outputs = outputs["model_outputs"]
         model_outputs = model_outputs[0].data.cpu().numpy()
         alignments = outputs["alignments"]


### PR DESCRIPTION
Now we can pass, only at inference time, the conditioned speaker (the speaker with expressive speech recorded) to conditionate the style encoder, duration and pitch predictor. After that, the desired speaker embedding will be used, as: 

speaker_emb, cond_speaker emb 

encoder_output = encoder_output + cond_speaker_embd

style_emb = style_encoder(encoder_output)
encoder_output  += style_emb

pitch_emb = pitch_predictor(encoder_output)
encoder_output  += pitch_emb

dur_emb = duration_predictor(encoder_output)
encoder_output  += dur_emb

# Here we change the speaker embedding, removing the conditioned one and adding the desired one
encoder_output = encoder_output - cond_speaker_emb + speaker_emb

melspectrogram = decoder(encoder_output) 
