### PR TITLE
Adding Gradient Inverter Layer option

### DIFF
--- a/TTS/style_encoder/configs/style_encoder_config.py
+++ b/TTS/style_encoder/configs/style_encoder_config.py
@@ -61,6 +61,7 @@ class StyleEncoderConfig(Coqpit):
 
     # GRL additional configs
     use_grl_on_speakers_in_style_embedding: bool = False # Whether use or not GRL in style embedding output avoinding speaker information
+    use_inverter: bool = False # whether use gri instead of grl
     grl_alpha: float = 1 # GRL alpha, still one for all GRL's
 
     # GST-SE Additional Configs

--- a/TTS/style_encoder/layers/gri.py
+++ b/TTS/style_encoder/layers/gri.py
@@ -1,0 +1,44 @@
+import torch
+from torch.autograd import Function
+
+'''
+    Gradient Reversal Layer implementation (based on: https://github.com/jvanvugt/pytorch-domain-adaptation/blob/master/utils.py)
+
+    Gradient Reversal Layer from:
+    Unsupervised Domain Adaptation by Backpropagation (Ganin & Lempitsky, 2015)
+    Forward pass is the identity function. In the backward pass,
+    the upstream gradients are multiplied by -lambda (i.e. gradient is reversed)
+
+    
+    Gradient Inverter Layer is a gradient norm adaptation based on: https://www.isca-speech.org/archive/pdfs/ssw_2021/schnell21b_ssw.pdf
+
+    Here we use the only the exponential norm, to avoid infinity collapse
+'''
+
+# Function
+class GradientInverterLayer_(Function):
+    @staticmethod
+    def forward(ctx, input, lambda_):
+        ctx.lambda_ = lambda_
+        return input
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        lambda_ = ctx.lambda_ 
+        lambda_ = grad_output.new_tensor(lambda_)
+        grad_input = -lambda_ * grad_output
+
+        l2_norm = torch.exp(grad_output.norm(dim=1, p = 2)) # calculate l2 norm along the batches and apply exp to avoid infinity collapse
+        grad_input = grad_input*(1/l2_norm.unsqueeze(1).repeat(1,grad_input.shape[-1])) # Normalize gradients by the norm
+
+
+        return grad_input, None
+
+# Class to use in models
+class GradientInverterLayer(torch.nn.Module):
+    def __init__(self, lambda_ = 1):
+        super(GradientInverterLayer, self).__init__()
+        self.lambda_ = lambda_ 
+
+    def forward(self, x):
+        return GradientInverterLayer_.apply(x, self.lambda_)

--- a/TTS/tts/models/styleforward_tts.py
+++ b/TTS/tts/models/styleforward_tts.py
@@ -20,7 +20,7 @@ from TTS.tts.utils.styles import StyleManager, get_style_weighted_sampler
 # Import Style Encoder
 from TTS.style_encoder.style_encoder import StyleEncoder
 from TTS.style_encoder.layers.grl import GradientReversalLayer
-
+from TTS.style_encoder.layers.gri import GradientInverterLayer
 
 @dataclass
 class StyleForwardTTSArgs(Coqpit):
@@ -194,7 +194,10 @@ class StyleforwardTTS(BaseTTS):
         if(config.style_encoder_config.use_grl_on_speakers_in_style_embedding): #Already assuming that we can have different GRL in different layers
             style_embedding_dim = config.style_encoder_config.proj_dim if (config.style_encoder_config.use_proj_linear or config.style_encoder_config.use_nonlinear_proj) else config.style_encoder_config.style_embedding_dim
             self.speaker_classifier_using_style_embedding = nn.Linear(style_embedding_dim, self.num_speakers)
-            self.grl_on_speakers_in_style_embedding = GradientReversalLayer(config.style_encoder_config.grl_alpha) # Still assuming only one alpha value
+            if(config.style_encoder_config.use_inverter):
+                self.grl_on_speakers_in_style_embedding = GradientInverterLayer(config.style_encoder_config.grl_alpha)
+            else:
+                self.grl_on_speakers_in_style_embedding = GradientReversalLayer(config.style_encoder_config.grl_alpha) # Still assuming only one alpha value
         
         
         # # pass all config fields to `self`


### PR DESCRIPTION
GRI option implemented, using only the exponential based L2 norm, to avoid infinity collapse in denominator.

ref: https://www.isca-speech.org/archive/pdfs/ssw_2021/schnell21b_ssw.pdf